### PR TITLE
Install clang-tools during static-analysis job

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -20,6 +20,11 @@ jobs:
       image: caiotoledo/imu-rpc:latest
 
     steps:
+      - name: Install dependencies
+        run: |
+          apt update -qq
+          apt install clang-tools-10 -y
+
       - uses: actions/checkout@v2
 
       - name: Run Static Analysis


### PR DESCRIPTION
The docker image will not have this package anymore to decrease its size.